### PR TITLE
Use absolute URLs for social preview images

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -10,7 +10,7 @@
     <meta name="author" content="STICKnoLOGIC">
     <meta property="og:title" content="PayUs-as-a-Service">
     <meta property="og:description" content="PayUs-as-a-Service (PUaaS) is a free API that generates randomized payment reminder messages in various tones. Perfect for developers who need to send past-due invoice reminders but want to maintain different communication styles.">
-    <meta property="og:image" content="/og-image.png">
+    <meta property="og:image" content="https://puaas.sticknologic.is-a.dev/og-image.png">
     <meta property="og:url" content="https://puaas.sticknologic.is-a.dev/">
     <title>PayUs-as-a-Service</title>
 
@@ -20,7 +20,7 @@
     <meta property="twitter:url" content="https://puaas.sticknologic.is-a.dev/">
     <meta name="twitter:title" content="PayUs-as-a-Service">
     <meta name="twitter:description" content="PayUs-as-a-Service (PUaaS) is a free API that generates randomized payment reminder messages in various tones. Perfect for developers who need to send past-due invoice reminders but want to maintain different communication styles.">
-    <meta name="twitter:image" content="/og-image.png">
+    <meta name="twitter:image" content="https://puaas.sticknologic.is-a.dev/og-image.png">
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
Update public/docs.html to replace the relative '/og-image.png' with the absolute 'https://puaas.sticknologic.is-a.dev/og-image.png' in the og:image and twitter:image meta tags. This ensures social platforms can reliably fetch the preview image regardless of the current path or hosting context.